### PR TITLE
Cache preprocessed script solvers

### DIFF
--- a/src/yt/solver/solvers.ts
+++ b/src/yt/solver/solvers.ts
@@ -4,6 +4,14 @@ import { extract as extractSig } from "./sig.ts";
 import { extract as extractN } from "./n.ts";
 import { setupNodes } from "./setup.ts";
 
+const solversCache = new Map<
+  string,
+  {
+    n: ((val: string) => string) | null;
+    sig: ((val: string) => string) | null;
+  }
+>();
+
 export function preprocessPlayer(data: string): string {
   const ast = parse(data);
   const body = ast.body;
@@ -104,7 +112,12 @@ export function getFromPrepared(code: string): {
   n: ((val: string) => string) | null;
   sig: ((val: string) => string) | null;
 } {
+  const existing = solversCache.get(code);
+  if (existing) {
+    return existing;
+  }
   const resultObj = { n: null, sig: null };
   Function("_result", code)(resultObj);
+  solversCache.set(code, resultObj);
   return resultObj;
 }


### PR DESCRIPTION
I have been working on a project that wraps ejs and exposes it functionality in an http api. I noticed over time some memory leaks and performance issues. Tracking it down the best I could it seems that the culprit is likely due to every time main is called with a preprocessed script, it will get the solvers each time. Between 2 runs with the same preprocessed script the solvers shouldn't change.

By caching the solvers I noticed a significant drop in request times as well as a significant impact on memory leakage. 

Pre-cache:
<img width="1696" height="59" alt="image" src="https://github.com/user-attachments/assets/fb097ef7-dc8b-4375-835b-15be776aab66" />
Over 100 requests - 17.8ms avg response time

Post-cache:
<img width="1700" height="61" alt="image" src="https://github.com/user-attachments/assets/3e4311c7-2038-405f-acef-efbf5a0072bb" />
Over 100 requests - ~8ms avg response time

Will add some memory metrics in the morning