### PR TITLE
Include test data directory in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ source = "vcs"
 exclude = [
   "/.github/**",
   "/src/yt/solver/test/players/*",
+  "!/src/yt/solver/test/players/.gitignore",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
Currently, the `src/yt/solver/test/players` directory for test data only exists if the repository is cloned, and users of the source distribution tarball need to manually create this directory before they can run tests or else `download.ts` will error. This PR fixes that