### PR TITLE
Fix windows build with bun and wrapper files

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -49,7 +49,7 @@ def build_bundle_cmds():
 
     elif bun := shutil.which("bun"):
         name = "bun"
-        install = ["bun", "install", "--frozen-lockfile"]
+        install = [bun, "install", "--frozen-lockfile"]
         bundle = [bun, "--bun", "run", "bundle"]
 
     elif npm := shutil.which("npm"):


### PR DESCRIPTION
Not explicitly providing the full path makes `.cmd` and `.bat` files not work; a simple oversight in coding and review.